### PR TITLE
fix: prevent data race on enum choices

### DIFF
--- a/values.go
+++ b/values.go
@@ -493,6 +493,8 @@ type Enum struct {
 }
 
 func EnumOf(v *string, choices ...string) *Enum {
+	// copy choices to avoid data race during unmarshaling
+	choices = append([]string{}, choices...)
 	return &Enum{
 		Choices: choices,
 		Value:   v,


### PR DESCRIPTION
Because we pass `codersdk.PostgresAuthDrivers` into multiple tests in coder we need to copy this slice or we run into data races. 