### PR TITLE
chore: hide flag completions by default

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -1,6 +1,8 @@
 package serpent
 
 import (
+	"strings"
+
 	"github.com/spf13/pflag"
 )
 
@@ -14,19 +16,24 @@ func (inv *Invocation) IsCompletionMode() bool {
 	return ok
 }
 
-// DefaultCompletionHandler is a handler that prints all  known flags and
-// subcommands that haven't been exhaustively set.
+// DefaultCompletionHandler is a handler that prints all the subcommands, or
+// all the options that haven't been exhaustively set, if the current word
+// starts with a dash.
 func DefaultCompletionHandler(inv *Invocation) []string {
+	_, cur := inv.CurWords()
 	var allResps []string
-	for _, cmd := range inv.Command.Children {
-		allResps = append(allResps, cmd.Name())
-	}
-	for _, opt := range inv.Command.Options {
-		_, isSlice := opt.Value.(pflag.SliceValue)
-		if opt.ValueSource == ValueSourceNone ||
-			opt.ValueSource == ValueSourceDefault ||
-			isSlice {
-			allResps = append(allResps, "--"+opt.Flag)
+	if strings.HasPrefix(cur, "-") {
+		for _, opt := range inv.Command.Options {
+			_, isSlice := opt.Value.(pflag.SliceValue)
+			if opt.ValueSource == ValueSourceNone ||
+				opt.ValueSource == ValueSourceDefault ||
+				isSlice {
+				allResps = append(allResps, "--"+opt.Flag)
+			}
+		}
+	} else {
+		for _, cmd := range inv.Command.Children {
+			allResps = append(allResps, cmd.Name())
 		}
 	}
 	return allResps

--- a/completion.go
+++ b/completion.go
@@ -31,10 +31,10 @@ func DefaultCompletionHandler(inv *Invocation) []string {
 				allResps = append(allResps, "--"+opt.Flag)
 			}
 		}
-	} else {
-		for _, cmd := range inv.Command.Children {
-			allResps = append(allResps, cmd.Name())
-		}
+		return allResps
+	}
+	for _, cmd := range inv.Command.Children {
+		allResps = append(allResps, cmd.Name())
 	}
 	return allResps
 }

--- a/completion_test.go
+++ b/completion_test.go
@@ -25,7 +25,7 @@ func TestCompletion(t *testing.T) {
 		io := fakeIO(i)
 		err := i.Run()
 		require.NoError(t, err)
-		require.Equal(t, "altfile\nfile\nrequired-flag\ntoupper\n--prefix\n--verbose\n", io.Stdout.String())
+		require.Equal(t, "altfile\nfile\nrequired-flag\ntoupper\n", io.Stdout.String())
 	})
 
 	t.Run("SubcommandNoPartial", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestCompletion(t *testing.T) {
 		io := fakeIO(i)
 		err := i.Run()
 		require.NoError(t, err)
-		require.Equal(t, "altfile\nfile\nrequired-flag\ntoupper\n--prefix\n--verbose\n", io.Stdout.String())
+		require.Equal(t, "altfile\nfile\nrequired-flag\ntoupper\n", io.Stdout.String())
 	})
 
 	t.Run("SubcommandComplete", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCompletion(t *testing.T) {
 
 	t.Run("ListFlags", func(t *testing.T) {
 		t.Parallel()
-		i := cmd().Invoke("required-flag", "")
+		i := cmd().Invoke("required-flag", "-")
 		i.Environ.Set(serpent.CompletionModeEnv, "1")
 		io := fakeIO(i)
 		err := i.Run()
@@ -60,7 +60,7 @@ func TestCompletion(t *testing.T) {
 
 	t.Run("ListFlagsAfterArg", func(t *testing.T) {
 		t.Parallel()
-		i := cmd().Invoke("altfile", "")
+		i := cmd().Invoke("altfile", "-")
 		i.Environ.Set(serpent.CompletionModeEnv, "1")
 		io := fakeIO(i)
 		err := i.Run()
@@ -70,7 +70,7 @@ func TestCompletion(t *testing.T) {
 
 	t.Run("FlagExhaustive", func(t *testing.T) {
 		t.Parallel()
-		i := cmd().Invoke("required-flag", "--req-bool", "--req-string", "foo bar", "--req-array", "asdf", "--req-array", "qwerty")
+		i := cmd().Invoke("required-flag", "--req-bool", "--req-string", "foo bar", "--req-array", "asdf", "--req-array", "qwerty", "-")
 		i.Environ.Set(serpent.CompletionModeEnv, "1")
 		io := fakeIO(i)
 		err := i.Run()
@@ -80,7 +80,7 @@ func TestCompletion(t *testing.T) {
 
 	t.Run("FlagShorthand", func(t *testing.T) {
 		t.Parallel()
-		i := cmd().Invoke("required-flag", "-b", "-s", "foo bar", "-a", "asdf")
+		i := cmd().Invoke("required-flag", "-b", "-s", "foo bar", "-a", "asdf", "-")
 		i.Environ.Set(serpent.CompletionModeEnv, "1")
 		io := fakeIO(i)
 		err := i.Run()
@@ -90,12 +90,12 @@ func TestCompletion(t *testing.T) {
 
 	t.Run("NoOptDefValueFlag", func(t *testing.T) {
 		t.Parallel()
-		i := cmd().Invoke("--verbose", "")
+		i := cmd().Invoke("--verbose", "-")
 		i.Environ.Set(serpent.CompletionModeEnv, "1")
 		io := fakeIO(i)
 		err := i.Run()
 		require.NoError(t, err)
-		require.Equal(t, "altfile\nfile\nrequired-flag\ntoupper\n--prefix\n", io.Stdout.String())
+		require.Equal(t, "--prefix\n", io.Stdout.String())
 	})
 
 	t.Run("EnumOK", func(t *testing.T) {


### PR DESCRIPTION
The vast majority of shell completion scripts hide flag completions by default, only showing them if the current word starts with a `-`. 
For example, all the fish completion scripts that ship with the shell itself do this, as do the `git` completions for `zsh`.

Additionally, in some shells, completion results are also shown in an order where flags starting with `--` are always displayed first, which is reasonably annoying.

Thanks to maf for picking up on this!