### PR TITLE
feat: export `DefaultHelpFn`

### DIFF
--- a/command.go
+++ b/command.go
@@ -479,7 +479,7 @@ func (inv *Invocation) run(state *runState) error {
 
 	if inv.Command.Handler == nil || errors.Is(state.flagParseErr, pflag.ErrHelp) {
 		if inv.Command.HelpHandler == nil {
-			return defaultHelpFn()(inv)
+			return DefaultHelpFn()(inv)
 		}
 		return inv.Command.HelpHandler(inv)
 	}

--- a/help.go
+++ b/help.go
@@ -322,9 +322,9 @@ func (lm *newlineLimiter) Write(p []byte) (int, error) {
 
 var usageWantsArgRe = regexp.MustCompile(`<.*>`)
 
-// defaultHelpFn returns a function that generates usage (help)
+// DefaultHelpFn returns a function that generates usage (help)
 // output for a given command.
-func defaultHelpFn() HandlerFunc {
+func DefaultHelpFn() HandlerFunc {
 	return func(inv *Invocation) error {
 		// We use stdout for help and not stderr since there's no straightforward
 		// way to distinguish between a user error and a help request.


### PR DESCRIPTION
Right now, there seems to be no clear way to programmatically print the help text generated with `--help`. This exports it so you can call it at-will.