### PR TITLE
feat: add 'DefaultFn' for dynamic default values

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -924,3 +924,144 @@ func TestCommand_OptionsWithSharedValue(t *testing.T) {
 	err = makeCmd("def.com", "alt-def.com").Invoke().Run()
 	require.Error(t, err, "default values are different")
 }
+
+func TestOptionSet_DefaultAndDefaultFn(t *testing.T) {
+	t.Parallel()
+	var val serpent.String
+	os := serpent.OptionSet{
+		{
+			Name:    "test",
+			Value:   &val,
+			Default: "static",
+			DefaultFn: func() string {
+				return "dynamic"
+			},
+		},
+	}
+	err := os.SetDefaults()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot set both Default and DefaultFn")
+}
+
+func TestCommand_DefaultFn(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name        string
+		args        []string
+		env         map[string]string
+		wantVerbose bool
+		wantLevel   string
+		wantDefault string // DefaultFn always populates Default field
+		wantSource  serpent.ValueSource
+	}
+
+	cases := []testCase{
+		{
+			name:        "no flags, DefaultFn uses dependency default",
+			args:        []string{},
+			env:         nil,
+			wantVerbose: false,
+			wantLevel:   "info",
+			wantDefault: "info",
+			wantSource:  serpent.ValueSourceDefault,
+		},
+		{
+			name:        "verbose flag set, DefaultFn sees it",
+			args:        []string{"--verbose"},
+			env:         nil,
+			wantVerbose: true,
+			wantLevel:   "debug",
+			wantDefault: "debug",
+			wantSource:  serpent.ValueSourceDefault,
+		},
+		{
+			name:        "verbose from env, DefaultFn sees it",
+			args:        []string{},
+			env:         map[string]string{"VERBOSE": "true"},
+			wantVerbose: true,
+			wantLevel:   "debug",
+			wantDefault: "debug",
+			wantSource:  serpent.ValueSourceDefault,
+		},
+		{
+			name:        "explicit log-level overrides DefaultFn",
+			args:        []string{"--verbose", "--log-level", "warn"},
+			env:         nil,
+			wantVerbose: true,
+			wantLevel:   "warn",
+			wantDefault: "debug", // DefaultFn still runs, populates Default
+			wantSource:  serpent.ValueSourceFlag,
+		},
+		{
+			name:        "log-level from env overrides DefaultFn",
+			args:        []string{"--verbose"},
+			env:         map[string]string{"LOG_LEVEL": "error"},
+			wantVerbose: true,
+			wantLevel:   "error",
+			wantDefault: "debug", // DefaultFn still runs, populates Default
+			wantSource:  serpent.ValueSourceEnv,
+		},
+		{
+			name:        "flag beats env for log-level",
+			args:        []string{"--log-level", "trace"},
+			env:         map[string]string{"LOG_LEVEL": "error", "VERBOSE": "true"},
+			wantVerbose: true,
+			wantLevel:   "trace",
+			wantDefault: "debug", // DefaultFn still runs, populates Default
+			wantSource:  serpent.ValueSourceFlag,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var verbose serpent.Bool
+			var logLevel serpent.String
+
+			cmd := &serpent.Command{
+				Options: serpent.OptionSet{
+					{
+						Name:    "verbose",
+						Flag:    "verbose",
+						Env:     "VERBOSE",
+						Value:   &verbose,
+						Default: "false",
+					},
+					{
+						Name:  "log-level",
+						Flag:  "log-level",
+						Env:   "LOG_LEVEL",
+						Value: &logLevel,
+						DefaultFn: func() string {
+							if verbose.Value() {
+								return "debug"
+							}
+							return "info"
+						},
+					},
+				},
+				Handler: func(i *serpent.Invocation) error {
+					return nil
+				},
+			}
+
+			inv := cmd.Invoke(tc.args...)
+			for k, v := range tc.env {
+				inv.Environ.Set(k, v)
+			}
+
+			err := inv.Run()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantVerbose, verbose.Value(), "verbose mismatch")
+			require.Equal(t, tc.wantLevel, logLevel.String(), "log-level mismatch")
+
+			// DefaultFn always populates the Default field (for JSON marshalling)
+			opt := cmd.Options.ByName("log-level")
+			require.Equal(t, tc.wantDefault, opt.Default, "Default field mismatch")
+			require.Equal(t, tc.wantSource, opt.ValueSource, "ValueSource mismatch")
+		})
+	}
+}

--- a/option.go
+++ b/option.go
@@ -57,9 +57,14 @@ type Option struct {
 	// Default is parsed into Value if set.
 	// Must be `""` if `DefaultFn` != nil
 	Default string `json:"default,omitempty"`
-	// DefaultFn is called to compute the default.
-	// It's evaluated during SetDefaults(), after env/flag/yaml parsing.
-	// It will populate the Default field for json marshalling.
+	// DefaultFn is called to compute the default value dynamically.
+	// It is evaluated during SetDefaults(), after env/flag/yaml parsing,
+	// but BEFORE static Default values are applied. This means if your
+	// DefaultFn depends on another option, that option must get its value
+	// from env, flag, or yaml - not from a static Default.
+	//
+	// The result populates the Default field (for JSON marshalling) and
+	// is applied to Value if no higher-priority source set it.
 	DefaultFn func() string `json:"-"`
 	// Value includes the types listed in values.go.
 	Value pflag.Value `json:"value,omitempty"`
@@ -336,8 +341,7 @@ func (optSet *OptionSet) SetDefaults() error {
 			continue
 		}
 
-		// If DefaultFn is set, it takes precedence over Default.
-		// Update the "Default" and use that going forward.
+		// Use DefaultFn to set the 'Default' field.
 		if opt.DefaultFn != nil {
 			if opt.Default != "" {
 				merr = multierror.Append(

--- a/option.go
+++ b/option.go
@@ -61,7 +61,7 @@ type Option struct {
 	// It is evaluated during SetDefaults(), after env/flag/yaml parsing,
 	// but BEFORE static Default values are applied. This means if your
 	// DefaultFn depends on another option, that option must get its value
-	// from env, flag, or yaml - not from a static Default.
+	// from env, flag, or yaml - not from a static Default or DefaultFn.
 	//
 	// The result populates the Default field (for JSON marshalling) and
 	// is applied to Value if no higher-priority source set it.

--- a/option.go
+++ b/option.go
@@ -351,6 +351,7 @@ func (optSet *OptionSet) SetDefaults() error {
 						opt.Name,
 					),
 				)
+				continue
 			}
 			opt.Default = opt.DefaultFn()
 		}

--- a/option.go
+++ b/option.go
@@ -55,7 +55,12 @@ type Option struct {
 	YAML string `json:"yaml,omitempty"`
 
 	// Default is parsed into Value if set.
+	// Must be `""` if `DefaultFn` != nil
 	Default string `json:"default,omitempty"`
+	// DefaultFn is called to compute the default.
+	// It's evaluated during SetDefaults(), after env/flag/yaml parsing.
+	// It will populate the Default field for json marshalling.
+	DefaultFn func() string `json:"-"`
 	// Value includes the types listed in values.go.
 	Value pflag.Value `json:"value,omitempty"`
 
@@ -330,6 +335,22 @@ func (optSet *OptionSet) SetDefaults() error {
 			)
 			continue
 		}
+
+		// If DefaultFn is set, it takes precedence over Default.
+		// Update the "Default" and use that going forward.
+		if opt.DefaultFn != nil {
+			if opt.Default != "" {
+				merr = multierror.Append(
+					merr,
+					xerrors.Errorf(
+						"option %q: cannot set both Default and DefaultFn",
+						opt.Name,
+					),
+				)
+			}
+			opt.Default = opt.DefaultFn()
+		}
+
 		groupByValue[opt.Value] = append(groupByValue[opt.Value], opt)
 	}
 

--- a/option.go
+++ b/option.go
@@ -324,6 +324,34 @@ func (optSet *OptionSet) SetDefaults() error {
 
 	var merr *multierror.Error
 
+	// All default values are queued up and applied at the same time.
+	// This ensures a deterministic output regardless of the order of the options.
+	//
+	// If the value is assigned immediately, the outcome of 1 DefaultFn can
+	// affect the outcome of another DefaultFn, which can lead to non-deterministic
+	// behavior depending on the order of the options.
+	queuedDefaultValues := make(map[int]string)
+	for i, opt := range *optSet {
+		// Use DefaultFn to set the 'Default' field.
+		if opt.DefaultFn != nil {
+			if opt.Default != "" {
+				merr = multierror.Append(
+					merr,
+					xerrors.Errorf(
+						"option %q: cannot set both Default and DefaultFn",
+						opt.Name,
+					),
+				)
+				continue
+			}
+			queuedDefaultValues[i] = opt.DefaultFn()
+		}
+	}
+
+	for i, v := range queuedDefaultValues {
+		(*optSet)[i].Default = v
+	}
+
 	// It's common to have multiple options with the same value to
 	// handle deprecation. We group the options by value so that we
 	// don't let other options overwrite user input.
@@ -339,21 +367,6 @@ func (optSet *OptionSet) SetDefaults() error {
 				),
 			)
 			continue
-		}
-
-		// Use DefaultFn to set the 'Default' field.
-		if opt.DefaultFn != nil {
-			if opt.Default != "" {
-				merr = multierror.Append(
-					merr,
-					xerrors.Errorf(
-						"option %q: cannot set both Default and DefaultFn",
-						opt.Name,
-					),
-				)
-				continue
-			}
-			opt.Default = opt.DefaultFn()
 		}
 
 		groupByValue[opt.Value] = append(groupByValue[opt.Value], opt)

--- a/option_test.go
+++ b/option_test.go
@@ -328,6 +328,55 @@ func TestOptionSet_DefaultFn(t *testing.T) {
 	require.Equal(t, os.ByName("set-overridden").Default, "set-by-default-fn")
 }
 
+// TestOptionSet_DefaultFnRace tests the racing behavior of DefaultFns when
+// they reference each other
+//
+// In this test if the DefaultFns are not properly isolated, then defaults for
+// the earlier values affect the later ones.
+// The DefaultFn does not support referencing other option defaults.
+func TestOptionSet_DefaultFnRace(t *testing.T) {
+	t.Parallel()
+	var (
+		def serpent.String
+		a   serpent.String
+		b   serpent.String
+		c   serpent.String
+	)
+	os := serpent.OptionSet{
+		{
+			Name:    "default",
+			Default: "default", // Even this you cannot use
+			Value:   &def,
+		},
+		{
+			Name:      "a",
+			Value:     &a,
+			DefaultFn: func() string { return def.String() + "a" },
+		},
+		{
+			Name:      "b",
+			Value:     &b,
+			DefaultFn: func() string { return a.String() + "b" },
+		},
+		{
+			Name:      "c",
+			Value:     &c,
+			DefaultFn: func() string { return b.String() + "c" },
+		},
+	}
+	err := os.SetDefaults()
+	require.NoError(t, err)
+
+	require.Equal(t, a.String(), "a")
+	require.Equal(t, os.ByName("a").Default, "a")
+
+	require.Equal(t, b.String(), "b")
+	require.Equal(t, os.ByName("b").Default, "b")
+
+	require.Equal(t, c.String(), "c")
+	require.Equal(t, os.ByName("c").Default, "c")
+}
+
 func compareOptionsExceptValues(t *testing.T, exp, found serpent.Option) {
 	t.Helper()
 

--- a/option_test.go
+++ b/option_test.go
@@ -285,6 +285,49 @@ func TestOptionSet_JsonMarshal(t *testing.T) {
 	})
 }
 
+func TestOptionSet_DefaultFn(t *testing.T) {
+	t.Parallel()
+	var verbose serpent.Bool
+	var logLevel serpent.String
+	var setByEnv serpent.String
+	os := serpent.OptionSet{
+		{
+			Name:    "verbose",
+			Env:     "VERBOSE",
+			Value:   &verbose,
+			Default: "false",
+		},
+		{
+			Name:  "log-level",
+			Value: &logLevel,
+			DefaultFn: func() string {
+				if verbose.Value() {
+					return "debug"
+				}
+				return "info"
+			},
+		},
+		{
+			Name:  "set-overridden",
+			Value: &setByEnv,
+			Env:   "SET_OVERRIDDEN",
+			DefaultFn: func() string {
+				return "set-by-default-fn"
+			},
+		},
+	}
+	// Simulate VERBOSE=true from env
+	err := os.ParseEnv([]serpent.EnvVar{{Name: "VERBOSE", Value: "true"}, {Name: "SET_OVERRIDDEN", Value: "set-by-env"}})
+	require.NoError(t, err)
+	err = os.SetDefaults()
+	require.NoError(t, err)
+	require.Equal(t, "debug", logLevel.String())
+	require.Equal(t, "set-by-env", setByEnv.String())
+	require.Equal(t, os.ByName("log-level").Default, "debug")
+	require.Equal(t, os.ByName("set-overridden").Value.String(), "set-by-env")
+	require.Equal(t, os.ByName("set-overridden").Default, "set-by-default-fn")
+}
+
 func compareOptionsExceptValues(t *testing.T, exp, found serpent.Option) {
 	t.Helper()
 


### PR DESCRIPTION
Adds an ability to dynamically decide defaults based on other flags. 

Usage in Coderd:
```golang
Name:        "Secure Auth Cookie",
DefaultFn: func() string {
  return strconv.FormatBool(c.AccessURL.Scheme == "https")
},
```

This is not perfect, because if the `AccessURL` flag is set via a default, then there is a race condition. The race is which flag is parsed first.

Ideally we have some dependency tree, and a `DependsOn: []string` style syntax. So flags can be processed in the right order.

But honestly that is so overkill. The default for `Secure` cookies today is `false`. In the race condition, it ends up being `false` in both cases. 