### PR TITLE
fix: allow empty environment variable values to override defaults

### DIFF
--- a/option.go
+++ b/option.go
@@ -292,15 +292,7 @@ func (optSet *OptionSet) ParseEnv(vs []EnvVar) error {
 			// because the agent lacked the environment variables to authenticate with Git.
 			envVal, ok = envs[`HOMEBREW_`+opt.Env]
 		}
-		// Currently, empty values are treated as if the environment variable is
-		// unset. This behavior is technically not correct as there is now no
-		// way for a user to change a Default value to an empty string from
-		// the environment. Unfortunately, we have old configuration files
-		// that rely on the faulty behavior.
-		//
-		// TODO: We should remove this hack in May 2023, when deployments
-		// have had months to migrate to the new behavior.
-		if !ok || envVal == "" {
+		if !ok {
 			continue
 		}
 

--- a/option_test.go
+++ b/option_test.go
@@ -152,7 +152,9 @@ func TestOptionSet_ParseEnv(t *testing.T) {
 
 		err = os.ParseEnv(serpent.ParseEnviron([]string{"CODER_WORKSPACE_NAME="}, "CODER_"))
 		require.NoError(t, err)
-		require.EqualValues(t, "defname", workspaceName)
+		// An explicitly empty environment variable should override the
+		// default value, allowing users to clear a default.
+		require.EqualValues(t, "", workspaceName)
 	})
 
 	t.Run("StringSlice", func(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -155,6 +155,32 @@ func TestOptionSet_ParseEnv(t *testing.T) {
 		// An explicitly empty environment variable should override the
 		// default value, allowing users to clear a default.
 		require.EqualValues(t, "", workspaceName)
+		require.Equal(t, serpent.ValueSourceEnv, os[0].ValueSource)
+	})
+
+	t.Run("EmptyValueUnset", func(t *testing.T) {
+		t.Parallel()
+
+		var workspaceName serpent.String
+
+		os := serpent.OptionSet{
+			serpent.Option{
+				Name:    "Workspace Name",
+				Value:   &workspaceName,
+				Default: "defname",
+				Env:     "WORKSPACE_NAME",
+			},
+		}
+
+		err := os.SetDefaults()
+		require.NoError(t, err)
+
+		// An env var that is not present at all should preserve the
+		// default value.
+		err = os.ParseEnv(serpent.ParseEnviron([]string{}, "CODER_"))
+		require.NoError(t, err)
+		require.EqualValues(t, "defname", workspaceName)
+		require.Equal(t, serpent.ValueSourceDefault, os[0].ValueSource)
 	})
 
 	t.Run("StringSlice", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://linear.app/codercom/issue/PLAT-156

## Problem

Empty string variable values are treated as unset: `VAR=""`.
Unset variables do not override defaults.

So setting `CODER_LOGGING_HUMAN=""` does not disable the default behavior of human logging on.

## Change

Remove the `|| envVal == ""` check from `ParseEnv()` in `option.go`. The original code had a comment acknowledging this was a hack with a TODO to remove it in May 2023, after deployments had time to migrate. That deadline passed over three years ago.

### Before
```go
if !ok || envVal == "" {
    continue
}
```

### After
```go
if !ok {
    continue
}
```

The `EmptyValue` test is updated to assert the corrected behavior: an explicitly empty env var now overrides the default.

> Generated with [Coder Agents](https://coder.com/agents)